### PR TITLE
refactor(Cargo): updated Cargo.tomls for publishing and added README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "xdr-rs-serialize"
 version = "0.1.0"
-authors = ["Kyle Bartush <kbartush@kochava.com>"]
+authors = ["Kochavalabs <dev@mazzaroth.io>"]
+description = "XDR object serialization for Rust"
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/kochavalabs/xdr-rs-serialize"
+repository = "https://github.com/kochavalabs/xdr-rs-serialize"
 edition = "2018"
+keywords = ["xdr", "serialization"]
+exclude = [ "example/*", "derive/*" ]
 
-[dependencies]
-xdr-rs-serialize-derive = { path = "xdr-rs-serialize-derive" }
+[dev-dependencies]
+xdr-rs-serialize-derive = { version = "0.1.0", path = "xdr-rs-serialize-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/kochavalabs/xdr-rs-serialize"
 repository = "https://github.com/kochavalabs/xdr-rs-serialize"
 edition = "2018"
 keywords = ["xdr", "serialization"]
-exclude = [ "example/*", "derive/*" ]
+exclude = [ "example/*", "xdr-rs-serialize-derive/*" ]
 
 [dev-dependencies]
 xdr-rs-serialize-derive = { version = "0.1.0", path = "xdr-rs-serialize-derive" }

--- a/xdr-rs-serialize-derive/Cargo.toml
+++ b/xdr-rs-serialize-derive/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "xdr-rs-serialize-derive"
 version = "0.1.0"
-authors = ["Kyle Bartush <kbartush@kochava.com>"]
+authors = ["Kochavalabs <dev@mazzaroth.io>"]
+description = "XDR object serialization for Rust"
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/kochavalabs/xdr-rs-serialize"
+repository = "https://github.com/kochavalabs/xdr-rs-serialize"
 edition = "2018"
+keywords = ["xdr", "serialization"]
 
 [dependencies]
 syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
@@ -10,4 +16,5 @@ quote = "0.6.8"
 proc-macro2 = "0.4"
 
 [lib]
+name = "xdr_rs_serialize_derive"
 proc-macro = true

--- a/xdr-rs-serialize-derive/README.md
+++ b/xdr-rs-serialize-derive/README.md
@@ -6,7 +6,7 @@ Derivation macros to derive the serialization and deserialization of objects usi
 
 ```toml
 [dependencies]
-xdr-rs-serialize = "0.1"
+xdr-rs-serialize-derive = "0.1.0"
 ```
 
 ## License

--- a/xdr-rs-serialize-derive/README.md
+++ b/xdr-rs-serialize-derive/README.md
@@ -1,0 +1,14 @@
+# xdr-rs-serialize-derive
+
+Derivation macros to derive the serialization and deserialization of objects using XDR.
+
+## Add dependency
+
+```toml
+[dependencies]
+xdr-rs-serialize = "0.1"
+```
+
+## License
+
+[MIT](https://choosealicense.com/licenses/mit/)


### PR DESCRIPTION
Will be publishing 2 crates, the base and the derive library.

Made the derive library a dev dependency as only used for tests.

Added a basic README for the derive library for publishing the crate.