### PR TITLE
Adding json formatting to XDROut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ exclude = [ "example/*", "xdr-rs-serialize-derive/*" ]
 
 [dev-dependencies]
 xdr-rs-serialize-derive = { version = "0.1.0-alpha", path = "xdr-rs-serialize-derive" }
+
+[dependencies]
+base64 = "0.11.0"
+hex = "0.4.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@
 pub enum Error {
     UnknownError,
 
+    ErrorUnimplemented,
+
     ByteBadFormat,
     BoolBadFormat,
     IntegerBadFormat,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -272,13 +272,12 @@ impl XDROut for String {
                 NN => b"\\n",
                 RR => b"\\r",
                 TT => b"\\t",
-                _ => panic!("Invalid character")
+                _ => panic!("Invalid character"),
             };
-            
+
             written += out.write(to_write).unwrap();
 
             start = i + 1
-             
         }
         if start != bytes.len() {
             written += out.write(&bytes[start..]).unwrap();

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -333,6 +333,10 @@ fn impl_xdr_out_macro(ast: &syn::DeriveInput) -> TokenStream {
                         #(#calls)*
                         Ok(written)
                     }
+
+                    fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
+                        Err(Error::ErrorUnimplemented)
+                    }
                 }
             }
         }
@@ -346,6 +350,10 @@ fn impl_xdr_out_macro(ast: &syn::DeriveInput) -> TokenStream {
                             #(#names::#matches)*
                             _ => Err(Error::InvalidEnumValue)
                         }
+                    }
+
+                    fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
+                        Err(Error::ErrorUnimplemented)
                     }
                 }
             }


### PR DESCRIPTION
This will only add JSON formatting for the base XDR types. The main purpose of this work was to enable insertion using SQL queries by serializing these types to those that can be used inside a string sql query.