### PR TITLE
Adding json formatting to XDROut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ xdr-rs-serialize-derive = { version = "0.1.0-alpha", path = "xdr-rs-serialize-de
 [dependencies]
 base64 = "0.11.0"
 hex = "0.4.0"
+json = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ exclude = [ "example/*", "xdr-rs-serialize-derive/*" ]
 
 [dev-dependencies]
 xdr-rs-serialize-derive = { version = "0.1.0-alpha", path = "xdr-rs-serialize-derive" }
+
+[dependencies]
+base64 = "0.11.0"
+hex = "0.4.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@
 pub enum Error {
     UnknownError,
 
+    ErrorUnimplemented,
+
     ByteBadFormat,
     BoolBadFormat,
     IntegerBadFormat,

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 pub enum Error {
     UnknownError,
 
-    ErrorUnimplemented,
+    Unimplemented,
 
     ByteBadFormat,
     BoolBadFormat,
@@ -21,4 +21,6 @@ pub enum Error {
 
     BadArraySize,
     InvalidPadding,
+
+    InvalidJson,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,3 @@ pub mod ser;
 #[cfg(test)]
 #[macro_use]
 extern crate xdr_rs_serialize_derive;
-
-pub use de::{read_fixed_array, read_var_array, read_var_string, XDRIn};
-pub use error::Error;
-pub use ser::{write_fixed_array, write_var_array, write_var_string, XDROut};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -272,13 +272,12 @@ impl XDROut for String {
                 NN => b"\\n",
                 RR => b"\\r",
                 TT => b"\\t",
-                _ => panic!("Invalid character")
+                _ => panic!("Invalid character"),
             };
-            
+
             written += out.write(to_write).unwrap();
 
             start = i + 1
-             
         }
         if start != bytes.len() {
             written += out.write(&bytes[start..]).unwrap();

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -922,7 +922,8 @@ mod tests {
 
         let mut actual_second: Vec<u8> = Vec::new();
         let to_ser = TestStruct { one: 1.0, two: 2 };
-        let expected_second: Vec<u8> = r#"{"enum":1,"value":{"one":1.0,"two":2}}"#.as_bytes().to_vec();
+        let expected_second: Vec<u8> =
+            r#"{"enum":1,"value":{"one":1.0,"two":2}}"#.as_bytes().to_vec();
         TestUnion::Second(to_ser)
             .write_json(&mut actual_second)
             .unwrap();

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -241,7 +241,10 @@ fn get_members(data: &syn::DataStruct) -> Result<Vec<Member>, ()> {
 
 fn member_to_json_dict(mem: &Member) -> Result<String, ()> {
     let mut lines: Vec<String> = Vec::new();
-    let name_str = format!(r#"written += out.write("\"{}\":".as_bytes()).unwrap() as u64;"#, mem.name);
+    let name_str = format!(
+        r#"written += out.write("\"{}\":".as_bytes()).unwrap() as u64;"#,
+        mem.name
+    );
     lines.push(name_str);
 
     let out = match (
@@ -268,9 +271,10 @@ fn member_to_json_dict(mem: &Member) -> Result<String, ()> {
             "written += write_var_string_json(self.{}.clone(), {}, out)?;",
             name, var
         ),
-        (name, 0, var, false, false) => {
-            format!("written += write_var_array_json(&self.{}, {}, out)?;", name, var)
-        }
+        (name, 0, var, false, false) => format!(
+            "written += write_var_array_json(&self.{}, {}, out)?;",
+            name, var
+        ),
         _ => "".to_string(),
     };
     lines.push(out);
@@ -298,7 +302,6 @@ fn get_calls_struct_out_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::
     }
     lines.push(r#"written += out.write("}".as_bytes()).unwrap() as u64;"#.to_string());
     Ok(vec![lines.join("\n").parse().unwrap()])
-
 }
 
 fn get_calls_struct_out_xdr(data: &syn::DataStruct) -> Result<Vec<proc_macro2::TokenStream>, ()> {

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -482,6 +482,10 @@ fn impl_xdr_in_macro(ast: &syn::DeriveInput) -> TokenStream {
                             read
                         ))
                     }
+
+                    fn read_json(_json: json::JsonValue) -> Result<Self, Error> {
+                        Err(Error::Unimplemented)
+                    }
                 }
 
             }
@@ -496,6 +500,10 @@ fn impl_xdr_in_macro(ast: &syn::DeriveInput) -> TokenStream {
                             #(#matches)*
                             _ => Err(Error::InvalidEnumValue)
                         }
+                    }
+
+                    fn read_json(_json: json::JsonValue) -> Result<Self, Error> {
+                        Err(Error::Unimplemented)
                     }
                 }
             }

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -333,6 +333,10 @@ fn impl_xdr_out_macro(ast: &syn::DeriveInput) -> TokenStream {
                         #(#calls)*
                         Ok(written)
                     }
+
+                    fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
+                        Err(Error::ErrorUnimplemented)
+                    }
                 }
             }
         }
@@ -346,6 +350,10 @@ fn impl_xdr_out_macro(ast: &syn::DeriveInput) -> TokenStream {
                             #(#names::#matches)*
                             _ => Err(Error::InvalidEnumValue)
                         }
+                    }
+
+                    fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
+                        Err(Error::ErrorUnimplemented)
                     }
                 }
             }


### PR DESCRIPTION
This will only add JSON formatting for the base XDR types. The main purpose of this work was to enable insertion using json strings into a kvquery database.