### PR TITLE
fix: updating rust serialization for special case structs

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -742,6 +742,22 @@ mod tests {
         pub vector: Vec<u32>,
     }
 
+    #[derive(Default, XDROut)]
+    struct TestFixedSingle {
+        #[array(fixed = 3)]
+        pub t: Vec<u32>,
+    }
+
+    #[test]
+    fn test_fixed_array_good_json_single() {
+        let mut to_ser = TestFixedSingle::default();
+        to_ser.t.extend(vec![1, 2, 3]);
+        let expected: Vec<u8> = r#"[1,2,3]"#.as_bytes().to_vec();
+        let mut actual: Vec<u8> = Vec::new();
+        to_ser.write_json(&mut actual).unwrap();
+        assert_json!(expected, actual);
+    }
+
     #[test]
     fn test_fixed_array_good() {
         let mut to_ser = TestFixed::default();


### PR DESCRIPTION
Because of rust limitations, involving the inability to make generic
implementations with fixed length arrays, typedefs including fixed
length arrays are made into structs with a single property ('t'). This
update handles this edge case during serialization.