### PR TITLE
fix: updating rust serialization for special case structs

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -793,6 +793,22 @@ mod tests {
         assert_eq!(Err(Error::BadArraySize), result);
     }
 
+    #[derive(XDRIn, Debug, PartialEq)]
+    struct TestFixedArrayType {
+        #[array(fixed = 3)]
+        pub t: Vec<u32>,
+    }
+
+    #[test]
+    fn test_fixed_array_json_type() {
+        let to_des = r#"[1, 2, 3]"#.to_string();
+        let result: TestFixedArrayType = read_json_string(to_des).unwrap();
+        let expected = TestFixedArrayType {
+            t: vec![1, 2, 3],
+        };
+        assert_eq!(expected, result);
+    }
+
     #[test]
     fn test_void() {
         let to_des: Vec<u8> = vec![];
@@ -888,5 +904,30 @@ mod tests {
         let to_des = r#"{"enum":0,"value": "asdf"}"#.to_string();
         let result: Result<TestUnion, Error> = read_json_string(to_des);
         assert_eq!(Err(Error::UnsignedIntegerBadFormat), result);
+    }
+
+    #[derive(XDRIn, Debug, PartialEq)]
+    pub struct ID {
+        #[array(fixed = 32)]
+        pub t: Vec<u8>,
+    }
+
+    #[derive(XDRIn, Debug, PartialEq)]
+    pub struct User {
+        pub id: ID,
+
+        #[array(var = 80)]
+        pub name: String,
+    }
+
+    #[test]
+    fn test_array_complex() {
+        let to_des = r#"[{"id":"0000000000000000000000000000000000000000000000000000000000000000","name":"sam"}]"#.to_string();
+        let result: Vec<User> = read_json_string(to_des).unwrap();
+        let expected: Vec<User> = vec![User {
+            id: ID { t: vec![0;32] },
+            name: "sam".to_string(),
+        }];
+        assert_eq!(expected, result);
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -803,9 +803,7 @@ mod tests {
     fn test_fixed_array_json_type() {
         let to_des = r#"[1, 2, 3]"#.to_string();
         let result: TestFixedArrayType = read_json_string(to_des).unwrap();
-        let expected = TestFixedArrayType {
-            t: vec![1, 2, 3],
-        };
+        let expected = TestFixedArrayType { t: vec![1, 2, 3] };
         assert_eq!(expected, result);
     }
 
@@ -925,7 +923,7 @@ mod tests {
         let to_des = r#"[{"id":"0000000000000000000000000000000000000000000000000000000000000000","name":"sam"}]"#.to_string();
         let result: Vec<User> = read_json_string(to_des).unwrap();
         let expected: Vec<User> = vec![User {
-            id: ID { t: vec![0;32] },
+            id: ID { t: vec![0; 32] },
             name: "sam".to_string(),
         }];
         assert_eq!(expected, result);

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -465,7 +465,10 @@ fn get_calls_struct_in_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::T
         if members.len() == 1 && members[0].name == "t" {
             return "jval".to_string();
         }
-        format!(r#"obj.unwrap().get("{}").ok_or_else(|| Error::InvalidJson)?"#, i)
+        format!(
+            r#"obj.unwrap().get("{}").ok_or_else(|| Error::InvalidJson)?"#,
+            i
+        )
     };
     Ok(members
         .iter()

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -461,46 +461,67 @@ fn get_calls_struct_in_xdr(data: &syn::DataStruct) -> Result<Vec<proc_macro2::To
 
 fn get_calls_struct_in_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::TokenStream>, ()> {
     let members = get_members(data)?;
+    let obj_fun = |i: &proc_macro2::Ident| -> String {
+        if members.len() == 1 && members[0].name == "t" {
+            return "jval".to_string();
+        }
+        format!(r#"obj.unwrap().get("{}").ok_or_else(|| Error::InvalidJson)?"#, i)
+    };
     Ok(members
         .iter()
         .map(|i| match (&i.name, i.fixed, i.var, &i.v_type) {
             (name, 0, 0, v_type) => format!(
-                r#"let {}_result = {}::read_json(obj.get("{}").ok_or_else(|| Error::InvalidJson)?.clone())?;"#,
+                r#"let {}_result = {}::read_json({}.clone())?;"#,
                 name,
                 v_type.to_string().replace("<", "::<"),
-                name
+                obj_fun(name)
             )
             .parse()
             .unwrap(),
             (name, fixed, 0, v_type) if v_type.to_string().replace(" ", "") != "Vec<u8>" => {
                 format!(
-                    r#"let {}_result: {} = read_fixed_array_json({}, obj.get("{}").ok_or_else(|| Error::InvalidJson)?.clone())?;"#,
-                    name, v_type, fixed, name
+                    r#"let {}_result: {} = read_fixed_array_json({}, {}.clone())?;"#,
+                    name,
+                    v_type,
+                    fixed,
+                    obj_fun(name)
                 )
                 .parse()
                 .unwrap()
             }
             (name, 0, var, v_type) if v_type.to_string() == "String" => format!(
-                r#"let {}_result: {} = read_var_string_json({}, obj.get("{}").ok_or_else(|| Error::InvalidJson)?.clone())?;"#,
-                name, v_type, var, name
+                r#"let {}_result: {} = read_var_string_json({}, {}.clone())?;"#,
+                name,
+                v_type,
+                var,
+                obj_fun(name)
             )
             .parse()
             .unwrap(),
             (name, 0, var, v_type) if v_type.to_string().replace(" ", "") != "Vec<u8>" => format!(
-                r#"let {}_result: {} = read_var_array_json({}, obj.get("{}").ok_or_else(|| Error::InvalidJson)?.clone())?;"#,
-                name, v_type, var, name
+                r#"let {}_result: {} = read_var_array_json({}, {}.clone())?;"#,
+                name,
+                v_type,
+                var,
+                obj_fun(name)
             )
             .parse()
             .unwrap(),
             (name, fixed, 0, v_type) => format!(
-                r#"let {}_result: {} = read_fixed_opaque_json({}, obj.get("{}").ok_or_else(|| Error::InvalidJson)?.clone())?;"#,
-                name, v_type, fixed, name
+                r#"let {}_result: {} = read_fixed_opaque_json({}, {}.clone())?;"#,
+                name,
+                v_type,
+                fixed,
+                obj_fun(name)
             )
             .parse()
             .unwrap(),
             (name, 0, var, v_type) => format!(
-                r#"let {}_result: {} = read_var_opaque_json({}, obj.get("{}").ok_or_else(|| Error::InvalidJson)?.clone())?;"#,
-                name, v_type, var, name
+                r#"let {}_result: {} = read_var_opaque_json({}, {}.clone())?;"#,
+                name,
+                v_type,
+                var,
+                obj_fun(name)
             )
             .parse()
             .unwrap(),
@@ -601,15 +622,14 @@ fn impl_xdr_in_macro(ast: &syn::DeriveInput) -> TokenStream {
                     }
 
                     fn read_json(jval: json::JsonValue) -> Result<Self, Error> {
-                        match jval {
-                            json::JsonValue::Object(obj) =>  {
-                                #(#json_calls)*
-                                Ok( #name {
-                                    #(#struct_build_json)*
-                                })
-                            },
-                            _ => Err(Error::InvalidJson)
-                        }
+                        let obj = match &jval {
+                            json::JsonValue::Object(o) => Some(o),
+                            _ => None
+                        };
+                        #(#json_calls)*
+                        Ok( #name {
+                            #(#struct_build_json)*
+                        })
                     }
                 }
 


### PR DESCRIPTION
Because of rust limitations, involving the inability to make generic
implementations with fixed length arrays, typedefs including fixed
length arrays are made into structs with a single property ('t'). This
update handles this edge case during deserialization.