### PR TITLE
feat(errors): Update error definition and replace panics in generated code, updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdr-rs-serialize"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR object serialization for Rust"
 license = "MIT"
@@ -12,9 +12,9 @@ keywords = ["xdr", "serialization"]
 exclude = [ "example/*", "xdr-rs-serialize-derive/*" ]
 
 [dev-dependencies]
-xdr-rs-serialize-derive = { version = "0.3.0", path = "xdr-rs-serialize-derive" }
+xdr-rs-serialize-derive = { version = "0.3.1", path = "xdr-rs-serialize-derive" }
 
 [dependencies]
-base64 = "0.11.0"
+base64 = "0.13.0"
 hex = "0.4.0"
 json = "0.12.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -504,7 +504,10 @@ mod tests {
     #[test]
     fn test_uint_error() {
         let to_des: Vec<u8> = vec![255, 255, 255];
-        assert_eq!(Err(Error::unsigned_integer_bad_format()), u32::read_xdr(&to_des));
+        assert_eq!(
+            Err(Error::unsigned_integer_bad_format()),
+            u32::read_xdr(&to_des)
+        );
 
         let to_des = "true".to_string();
         let result: Result<u32, Error> = read_json_string(to_des);
@@ -550,7 +553,10 @@ mod tests {
     #[test]
     fn test_uhyper_error() {
         let to_des: Vec<u8> = vec![255, 255, 255, 255, 255, 255, 255];
-        assert_eq!(Err(Error::unsigned_hyper_bad_format()), u64::read_xdr(&to_des));
+        assert_eq!(
+            Err(Error::unsigned_hyper_bad_format()),
+            u64::read_xdr(&to_des)
+        );
 
         let to_des = "123".to_string();
         let result: Result<u64, Error> = read_json_string(to_des);
@@ -785,9 +791,18 @@ mod tests {
         let to_des2: Vec<u8> = vec![0, 1, 0, 1];
         let to_des3: Vec<u8> = vec![0, 0, 0, 3];
 
-        assert_eq!(Err(Error::invalid_enum_value()), TestEnum::read_xdr(&to_des1));
-        assert_eq!(Err(Error::invalid_enum_value()), TestEnum::read_xdr(&to_des2));
-        assert_eq!(Err(Error::invalid_enum_value()), TestEnum::read_xdr(&to_des3));
+        assert_eq!(
+            Err(Error::invalid_enum_value()),
+            TestEnum::read_xdr(&to_des1)
+        );
+        assert_eq!(
+            Err(Error::invalid_enum_value()),
+            TestEnum::read_xdr(&to_des2)
+        );
+        assert_eq!(
+            Err(Error::invalid_enum_value()),
+            TestEnum::read_xdr(&to_des3)
+        );
 
         let to_des = "4".to_string();
         let result: Result<TestEnum, Error> = read_json_string(to_des);
@@ -1070,7 +1085,10 @@ mod tests {
     #[test]
     fn test_union_error() {
         let to_des_1: Vec<u8> = vec![0, 0, 0, 3, 0x3f, 0x80, 0, 0, 0, 0, 0, 2];
-        assert_eq!(Err(Error::invalid_enum_value()), TestUnion::read_xdr(&to_des_1));
+        assert_eq!(
+            Err(Error::invalid_enum_value()),
+            TestUnion::read_xdr(&to_des_1)
+        );
 
         let to_des_2: Vec<u8> = vec![0, 0, 0, 0, 0x3f, 0x80];
         assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub struct Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind() {
-            _ => write!(f, "{:?}", self)
+            _ => write!(f, "{:?}", self),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,7 @@
-use std::error;
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Error {
-    UnknownError,
-
-    Unimplemented,
-
-    ByteBadFormat,
+pub enum ErrorKind {
     BoolBadFormat,
     IntegerBadFormat,
     UnsignedIntegerBadFormat,
@@ -17,7 +11,6 @@ pub enum Error {
     DoubleBadFormat,
     StringBadFormat,
 
-    VarOpaqueBadFormat,
     FixedArrayWrongSize,
     VarArrayWrongSize,
     InvalidEnumValue,
@@ -26,12 +19,119 @@ pub enum Error {
     InvalidPadding,
 
     InvalidJson,
+
+    Utf8Error(std::str::Utf8Error),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Error {
+    kind: ErrorKind,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self.kind() {
+            _ => write!(f, "{:?}", self)
+        }
     }
 }
 
-impl error::Error for Error {}
+impl Error {
+    fn from_kind(kind: ErrorKind) -> Self {
+        Error { kind }
+    }
+
+    fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
+
+    pub fn bool_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::BoolBadFormat,
+        }
+    }
+
+    pub fn integer_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::IntegerBadFormat,
+        }
+    }
+
+    pub fn unsigned_integer_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::UnsignedIntegerBadFormat,
+        }
+    }
+
+    pub fn hyper_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::HyperBadFormat,
+        }
+    }
+
+    pub fn unsigned_hyper_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::UnsignedHyperBadFormat,
+        }
+    }
+
+    pub fn float_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::FloatBadFormat,
+        }
+    }
+
+    pub fn double_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::DoubleBadFormat,
+        }
+    }
+
+    pub fn string_bad_format() -> Self {
+        Error {
+            kind: ErrorKind::StringBadFormat,
+        }
+    }
+
+    pub fn fixed_array_wrong_size() -> Self {
+        Error {
+            kind: ErrorKind::FixedArrayWrongSize,
+        }
+    }
+
+    pub fn var_array_wrong_size() -> Self {
+        Error {
+            kind: ErrorKind::VarArrayWrongSize,
+        }
+    }
+
+    pub fn invalid_enum_value() -> Self {
+        Error {
+            kind: ErrorKind::InvalidEnumValue,
+        }
+    }
+
+    pub fn bad_array_size() -> Self {
+        Error {
+            kind: ErrorKind::BadArraySize,
+        }
+    }
+
+    pub fn invalid_padding() -> Self {
+        Error {
+            kind: ErrorKind::InvalidPadding,
+        }
+    }
+
+    pub fn invalid_json() -> Self {
+        Error {
+            kind: ErrorKind::InvalidJson,
+        }
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(utf_err: std::str::Utf8Error) -> Self {
+        Error::from_kind(ErrorKind::Utf8Error(utf_err))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum ErrorKind {
     InvalidJson,
 
     Utf8Error(std::str::Utf8Error),
+    IOError(std::io::ErrorKind),
 }
 
 #[derive(Debug, PartialEq)]
@@ -133,5 +134,13 @@ impl Error {
 impl From<std::str::Utf8Error> for Error {
     fn from(utf_err: std::str::Utf8Error) -> Self {
         Error::from_kind(ErrorKind::Utf8Error(utf_err))
+    }
+}
+
+// Convert IO Error by storing only the ErrorKind for display
+// This ensures that our ErrorKind is still clonable
+impl From<std::io::Error> for Error {
+    fn from(io_err: std::io::Error) -> Self {
+        Error::from_kind(ErrorKind::IOError(io_err.kind()))
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -17,17 +17,17 @@ fn pad(written: u64, out: &mut Vec<u8>) -> Result<u64, Error> {
         0 => Ok(0),
         1 => match out.write(&[0]) {
             Ok(1) => Ok(1),
-            _ => Err(Error::InvalidPadding),
+            _ => Err(Error::invalid_padding()),
         },
         2 => match out.write(&[0, 0]) {
             Ok(2) => Ok(2),
-            _ => Err(Error::InvalidPadding),
+            _ => Err(Error::invalid_padding()),
         },
         3 => match out.write(&[0, 0, 0]) {
             Ok(3) => Ok(3),
-            _ => Err(Error::InvalidPadding),
+            _ => Err(Error::invalid_padding()),
         },
-        _ => Err(Error::InvalidPadding),
+        _ => Err(Error::invalid_padding()),
     }
 }
 
@@ -36,7 +36,7 @@ impl XDROut for bool {
         let to_write: u32 = if *self { 1 } else { 0 };
         match out.write(&to_write.to_be_bytes()) {
             Ok(4) => Ok(4),
-            _ => Err(Error::BoolBadFormat),
+            _ => Err(Error::bool_bad_format()),
         }
     }
 
@@ -44,7 +44,7 @@ impl XDROut for bool {
         let to_write = if !self { "false" } else { "true" };
         match out.write(to_write.as_bytes()) {
             Ok(len) => Ok(len as u64),
-            _ => Err(Error::BoolBadFormat),
+            _ => Err(Error::bool_bad_format()),
         }
     }
 }
@@ -53,14 +53,14 @@ impl XDROut for i32 {
     fn write_xdr(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         match out.write(&self.to_be_bytes()) {
             Ok(4) => Ok(4),
-            _ => Err(Error::IntegerBadFormat),
+            _ => Err(Error::integer_bad_format()),
         }
     }
     fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         let to_write = self.to_string();
         match out.write(to_write.as_bytes()) {
             Ok(len) => Ok(len as u64),
-            _ => Err(Error::IntegerBadFormat),
+            _ => Err(Error::integer_bad_format()),
         }
     }
 }
@@ -69,14 +69,14 @@ impl XDROut for u32 {
     fn write_xdr(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         match out.write(&self.to_be_bytes()) {
             Ok(4) => Ok(4),
-            _ => Err(Error::UnsignedIntegerBadFormat),
+            _ => Err(Error::unsigned_integer_bad_format()),
         }
     }
     fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         let to_write = self.to_string();
         match out.write(to_write.as_bytes()) {
             Ok(len) => Ok(len as u64),
-            _ => Err(Error::IntegerBadFormat),
+            _ => Err(Error::integer_bad_format()),
         }
     }
 }
@@ -85,14 +85,14 @@ impl XDROut for i64 {
     fn write_xdr(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         match out.write(&self.to_be_bytes()) {
             Ok(8) => Ok(8),
-            _ => Err(Error::HyperBadFormat),
+            _ => Err(Error::hyper_bad_format()),
         }
     }
     fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         let to_write = format!("\"{}\"", self.to_string());
         match out.write(to_write.as_bytes()) {
             Ok(len) => Ok(len as u64),
-            _ => Err(Error::IntegerBadFormat),
+            _ => Err(Error::integer_bad_format()),
         }
     }
 }
@@ -101,14 +101,14 @@ impl XDROut for u64 {
     fn write_xdr(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         match out.write(&self.to_be_bytes()) {
             Ok(8) => Ok(8),
-            _ => Err(Error::UnsignedHyperBadFormat),
+            _ => Err(Error::unsigned_hyper_bad_format()),
         }
     }
     fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         let to_write = format!("\"{}\"", self.to_string());
         match out.write(to_write.as_bytes()) {
             Ok(len) => Ok(len as u64),
-            _ => Err(Error::IntegerBadFormat),
+            _ => Err(Error::integer_bad_format()),
         }
     }
 }
@@ -117,7 +117,7 @@ impl XDROut for f32 {
     fn write_xdr(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         match out.write(&self.to_bits().to_be_bytes()) {
             Ok(4) => Ok(4),
-            _ => Err(Error::FloatBadFormat),
+            _ => Err(Error::float_bad_format()),
         }
     }
     fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
@@ -127,7 +127,7 @@ impl XDROut for f32 {
         }
         match out.write(to_write.as_bytes()) {
             Ok(len) => Ok(len as u64),
-            _ => Err(Error::IntegerBadFormat),
+            _ => Err(Error::integer_bad_format()),
         }
     }
 }
@@ -136,7 +136,7 @@ impl XDROut for f64 {
     fn write_xdr(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
         match out.write(&self.to_bits().to_be_bytes()) {
             Ok(8) => Ok(8),
-            _ => Err(Error::DoubleBadFormat),
+            _ => Err(Error::double_bad_format()),
         }
     }
     fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
@@ -146,7 +146,7 @@ impl XDROut for f64 {
         }
         match out.write(to_write.as_bytes()) {
             Ok(len) => Ok(len as u64),
-            _ => Err(Error::IntegerBadFormat),
+            _ => Err(Error::integer_bad_format()),
         }
     }
 }
@@ -205,7 +205,7 @@ impl XDROut for Vec<u8> {
                 written += len as u64;
             }
             _ => {
-                return Err(Error::IntegerBadFormat);
+                return Err(Error::integer_bad_format());
             }
         };
         written += out.write(b"\"").unwrap() as u64;
@@ -366,7 +366,7 @@ impl XDROut for String {
 
 pub fn write_fixed_array<T: XDROut>(val: &[T], size: u32, out: &mut Vec<u8>) -> Result<u64, Error> {
     if val.len() as u32 != size {
-        return Err(Error::FixedArrayWrongSize);
+        return Err(Error::fixed_array_wrong_size());
     }
     let mut written: u64 = 0;
     for item in val {
@@ -381,14 +381,14 @@ pub fn write_fixed_array_json<T: XDROut>(
     out: &mut Vec<u8>,
 ) -> Result<u64, Error> {
     if val.len() as u32 != size {
-        return Err(Error::FixedArrayWrongSize);
+        return Err(Error::fixed_array_wrong_size());
     }
     val.write_json(out)
 }
 
 pub fn write_fixed_opaque(val: &Vec<u8>, size: u32, out: &mut Vec<u8>) -> Result<u64, Error> {
     if val.len() as u32 != size {
-        return Err(Error::FixedArrayWrongSize);
+        return Err(Error::fixed_array_wrong_size());
     }
     out.extend(val);
     let mut written = val.len() as u64;
@@ -399,7 +399,7 @@ pub fn write_fixed_opaque(val: &Vec<u8>, size: u32, out: &mut Vec<u8>) -> Result
 pub fn write_fixed_opaque_json(val: &Vec<u8>, size: u32, out: &mut Vec<u8>) -> Result<u64, Error> {
     let len = val.len() as u32;
     if len != size {
-        return Err(Error::FixedArrayWrongSize);
+        return Err(Error::fixed_array_wrong_size());
     }
 
     if len <= 64 {
@@ -411,7 +411,7 @@ pub fn write_fixed_opaque_json(val: &Vec<u8>, size: u32, out: &mut Vec<u8>) -> R
                 written += len as u64;
             }
             _ => {
-                return Err(Error::IntegerBadFormat);
+                return Err(Error::integer_bad_format());
             }
         };
         written += out.write(b"\"").unwrap() as u64;
@@ -422,14 +422,14 @@ pub fn write_fixed_opaque_json(val: &Vec<u8>, size: u32, out: &mut Vec<u8>) -> R
 
 pub fn write_var_opaque(val: &Vec<u8>, size: u32, out: &mut Vec<u8>) -> Result<u64, Error> {
     if val.len() as u32 > size {
-        return Err(Error::BadArraySize);
+        return Err(Error::bad_array_size());
     }
     val.write_xdr(out)
 }
 
 pub fn write_var_opaque_json(val: &Vec<u8>, size: u32, out: &mut Vec<u8>) -> Result<u64, Error> {
     if val.len() as u32 > size {
-        return Err(Error::BadArraySize);
+        return Err(Error::bad_array_size());
     }
     val.write_json(out)
 }
@@ -440,7 +440,7 @@ pub fn write_var_array<T: XDROut>(
     out: &mut Vec<u8>,
 ) -> Result<u64, Error> {
     if val.len() as u32 > size {
-        return Err(Error::VarArrayWrongSize);
+        return Err(Error::var_array_wrong_size());
     }
     val.write_xdr(out)
 }
@@ -451,21 +451,21 @@ pub fn write_var_array_json<T: XDROut>(
     out: &mut Vec<u8>,
 ) -> Result<u64, Error> {
     if val.len() as u32 > size {
-        return Err(Error::VarArrayWrongSize);
+        return Err(Error::var_array_wrong_size());
     }
     val.write_json(out)
 }
 
 pub fn write_var_string(val: String, size: u32, out: &mut Vec<u8>) -> Result<u64, Error> {
     if val.len() as u32 > size && size != 0 {
-        return Err(Error::VarArrayWrongSize);
+        return Err(Error::var_array_wrong_size());
     }
     val.write_xdr(out)
 }
 
 pub fn write_var_string_json(val: String, size: u32, out: &mut Vec<u8>) -> Result<u64, Error> {
     if val.len() as u32 > size && size != 0 {
-        return Err(Error::VarArrayWrongSize);
+        return Err(Error::var_array_wrong_size());
     }
     val.write_json(out)
 }
@@ -771,7 +771,7 @@ mod tests {
         };
         let mut actual: Vec<u8> = Vec::new();
         let result = to_ser.write_xdr(&mut actual);
-        assert_eq!(Err(Error::VarArrayWrongSize), result);
+        assert_eq!(Err(Error::var_array_wrong_size()), result);
     }
 
     #[derive(XDROut)]
@@ -865,9 +865,9 @@ mod tests {
         let to_ser = TestFixed::default();
         let mut actual: Vec<u8> = Vec::new();
         let result = to_ser.write_xdr(&mut actual);
-        assert_eq!(Err(Error::FixedArrayWrongSize), result);
+        assert_eq!(Err(Error::fixed_array_wrong_size()), result);
         let result2 = to_ser.write_json(&mut actual);
-        assert_eq!(Err(Error::FixedArrayWrongSize), result2);
+        assert_eq!(Err(Error::fixed_array_wrong_size()), result2);
     }
 
     #[test]
@@ -905,9 +905,9 @@ mod tests {
         to_ser.vector.extend(vec![1, 2, 3, 4]);
         let mut actual: Vec<u8> = Vec::new();
         let result = to_ser.write_xdr(&mut actual);
-        assert_eq!(Err(Error::VarArrayWrongSize), result);
+        assert_eq!(Err(Error::var_array_wrong_size()), result);
         let result2 = to_ser.write_json(&mut actual);
-        assert_eq!(Err(Error::VarArrayWrongSize), result2);
+        assert_eq!(Err(Error::var_array_wrong_size()), result2);
     }
 
     #[test]
@@ -1036,9 +1036,9 @@ mod tests {
     fn test_enum_bad() {
         let mut buffer: Vec<u8> = Vec::new();
         let result = TestEnumBad::Value.write_xdr(&mut buffer);
-        assert_eq!(Err(Error::InvalidEnumValue), result);
+        assert_eq!(Err(Error::invalid_enum_value()), result);
         let result2 = TestEnumBad::Value.write_json(&mut buffer);
-        assert_eq!(Err(Error::InvalidEnumValue), result2);
+        assert_eq!(Err(Error::invalid_enum_value()), result2);
     }
 
     #[derive(XDROut)]

--- a/xdr-rs-serialize-derive/Cargo.toml
+++ b/xdr-rs-serialize-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xdr-rs-serialize-derive"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR object serialization for Rust"
 license = "MIT"
@@ -11,9 +11,9 @@ edition = "2018"
 keywords = ["xdr", "serialization"]
 
 [dependencies]
-syn = { version = "0.15.12" , features = ["full", "extra-traits", "parsing"] }
-quote = "0.6.8"
-proc-macro2 = "0.4"
+syn = { version = "1.0.95", features = ["full", "extra-traits", "parsing"] }
+quote = "1.0"
+proc-macro2 = "1.0"
 
 [lib]
 name = "xdr_rs_serialize_derive"

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -314,7 +314,7 @@ fn member_to_json_dict(mem: &Member, skip_name: bool) -> Result<String, ()> {
     let mut lines: Vec<String> = Vec::new();
     if !skip_name {
         let name_str = format!(
-            r#"written += out.write("\"{}\":".as_bytes()).unwrap() as u64;"#,
+            r#"written += out.write("\"{}\":".as_bytes())? as u64;"#,
             mem.name
         );
         lines.push(name_str);
@@ -361,9 +361,9 @@ fn get_calls_struct_out_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::
         lines.push(member_to_json_dict(&members[0], true)?);
         return Ok(vec![lines.join("\n").parse().unwrap()]);
     }
-    lines.push(r#"written += out.write("{".as_bytes()).unwrap() as u64;"#.to_string());
+    lines.push(r#"written += out.write("{".as_bytes())? as u64;"#.to_string());
     if members.len() == 0 {
-        lines.push(r#"written += out.write("}".as_bytes()).unwrap() as u64;"#.to_string());
+        lines.push(r#"written += out.write("}".as_bytes())? as u64;"#.to_string());
         return Ok(vec![lines.join("\n").parse().unwrap()]);
     }
     let mem = members[0].clone();
@@ -377,7 +377,7 @@ fn get_calls_struct_out_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::
         lines.push(r#"written += out.write(",".as_bytes()).unwrap() as u64;"#.to_string());
         lines.push(member_to_json_dict(mem, false)?);
     }
-    lines.push(r#"written += out.write("}".as_bytes()).unwrap() as u64;"#.to_string());
+    lines.push(r#"written += out.write("}".as_bytes())? as u64;"#.to_string());
     Ok(vec![lines.join("\n").parse().unwrap()])
 }
 

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -489,7 +489,7 @@ fn get_calls_struct_in_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::T
             return "jval".to_string();
         }
         format!(
-            r#"obj.unwrap().get("{}").ok_or_else(|| Error::InvalidJson)?"#,
+            r#"obj.unwrap().get("{}").ok_or_else(|| Error::invalid_json())?"#,
             i
         )
     };
@@ -608,14 +608,14 @@ fn impl_xdr_out_macro(ast: &syn::DeriveInput) -> TokenStream {
                     fn write_xdr(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
                         match *self {
                             #(#names::#xdr_matches)*
-                            _ => Err(Error::InvalidEnumValue)
+                            _ => Err(Error::invalid_enum_value())
                         }
                     }
 
                     fn write_json(&self, out: &mut Vec<u8>) -> Result<u64, Error> {
                         match *self {
                             #(#names2::#json_matches)*
-                            _ => Err(Error::InvalidEnumValue)
+                            _ => Err(Error::invalid_enum_value())
                         }
                     }
                 }
@@ -671,18 +671,18 @@ fn impl_xdr_in_macro(ast: &syn::DeriveInput) -> TokenStream {
                         let enum_val = i32::read_xdr(buffer)?.0;
                         match enum_val {
                             #(#matches_xdr)*
-                            _ => Err(Error::InvalidEnumValue)
+                            _ => Err(Error::invalid_enum_value())
                         }
                     }
 
                     fn read_json(jval: json::JsonValue) -> Result<Self, Error> {
                         match jval {
                             json::JsonValue::Object(obj) =>  {
-                                let enum_index = i32::read_json(obj.get("type").ok_or_else(|| Error::InvalidJson)?.clone())?;
-                                let enum_val = obj.get("data").ok_or_else(|| Error::InvalidJson)?;
+                                let enum_index = i32::read_json(obj.get("type").ok_or_else(|| Error::invalid_json())?.clone())?;
+                                let enum_val = obj.get("data").ok_or_else(|| Error::invalid_json())?;
                                 match enum_index {
                                     #(#matches_json1)*
-                                    _ => Err(Error::InvalidEnumValue)
+                                    _ => Err(Error::invalid_enum_value())
                                 }
                             },
                             json::JsonValue::Number(num) =>  {
@@ -690,10 +690,10 @@ fn impl_xdr_in_macro(ast: &syn::DeriveInput) -> TokenStream {
                                 let enum_val : json::JsonValue = json::JsonValue::new_object();
                                 match enum_index {
                                     #(#matches_json2)*
-                                    _ => Err(Error::InvalidEnumValue)
+                                    _ => Err(Error::invalid_enum_value())
                                 }
                             },
-                            _ => Err(Error::InvalidEnumValue)
+                            _ => Err(Error::invalid_enum_value())
                         }
                     }
                 }

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -258,7 +258,7 @@ fn get_calls_enum_out_json(data: &syn::DataEnum) -> Result<Vec<proc_macro2::Toke
             (name, false, i) => {
                 result.push(
                     format!(
-                        r#"{}(ref val) => {{let mut written = 0; written += out.write("{{\"type\":".as_bytes()).unwrap() as u64;  written += ({} as i32).write_json(out)?; written += out.write(",\"data\":".as_bytes()).unwrap() as u64; written +=  val.write_json(out)?; written += out.write("}}".as_bytes()).unwrap() as u64; Ok(written)}},"#,
+                        r#"{}(ref val) => {{let mut written = 0; written += out.write("{{\"type\":".as_bytes())? as u64;  written += ({} as i32).write_json(out)?; written += out.write(",\"data\":".as_bytes())? as u64; written +=  val.write_json(out)?; written += out.write("}}".as_bytes())? as u64; Ok(written)}},"#,
                         name, i
                     )
                     .parse()
@@ -369,12 +369,12 @@ fn get_calls_struct_out_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::
     let mem = members[0].clone();
     lines.push(member_to_json_dict(&mem, false)?);
     if members.len() == 1 {
-        lines.push(r#"written += out.write("}".as_bytes()).unwrap() as u64;"#.to_string());
+        lines.push(r#"written += out.write("}".as_bytes())? as u64;"#.to_string());
         return Ok(vec![lines.join("\n").parse().unwrap()]);
     }
 
     for mem in members[1..].iter() {
-        lines.push(r#"written += out.write(",".as_bytes()).unwrap() as u64;"#.to_string());
+        lines.push(r#"written += out.write(",".as_bytes())? as u64;"#.to_string());
         lines.push(member_to_json_dict(mem, false)?);
     }
     lines.push(r#"written += out.write("}".as_bytes())? as u64;"#.to_string());

--- a/xdr-rs-serialize-derive/src/lib.rs
+++ b/xdr-rs-serialize-derive/src/lib.rs
@@ -489,7 +489,7 @@ fn get_calls_struct_in_json(data: &syn::DataStruct) -> Result<Vec<proc_macro2::T
             return "jval".to_string();
         }
         format!(
-            r#"obj.unwrap().get("{}").ok_or_else(|| Error::invalid_json())?"#,
+            r#"obj.ok_or_else(|| Error::invalid_json())?.get("{}").ok_or_else(|| Error::invalid_json())?"#,
             i
         )
     };


### PR DESCRIPTION
# Description

This update adds an Error struct for the serialize and deserialize functions, replacing the Error enum return.
Added error types for the std errors that were currently being unwrapped in the generated code so they can be returned as Errors instead.

- Fixed a panic caused by the unwrap of None in deserializing invalid json struct.
- Updated all dependencies to latest versions